### PR TITLE
feat: GUI에 실행 및 종료 버튼 추가

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -108,21 +108,31 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow) {
 // GUI 처리
 LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     static HWND hButton;
+    static HWND hExitButton; // 종료 버튼 핸들 추가
 
     switch (msg) {
     case WM_CREATE:
-        hButton = CreateWindow(L"BUTTON", L".exe 선택 및 실행",
+        // 기존 버튼 수정: 레이블 변경, x 좌표 및 너비 조정
+        hButton = CreateWindow(L"BUTTON", L"프로그램 실행",
             WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON,
-            100, 60, 200, 40,
+            50, 60, 140, 40, // x=50, 너비=140
             hwnd, (HMENU)1, (HINSTANCE)GetWindowLongPtr(hwnd, GWLP_HINSTANCE), NULL);
+
+        // 새 버튼 "종료" 추가
+        hExitButton = CreateWindow(L"BUTTON", L"종료",
+            WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON,
+            210, 60, 140, 40, // x=210, 너비=140, y는 동일
+            hwnd, (HMENU)2, (HINSTANCE)GetWindowLongPtr(hwnd, GWLP_HINSTANCE), NULL);
         break;
 
     case WM_COMMAND:
-        if (LOWORD(wParam) == 1) {
+        if (LOWORD(wParam) == 1) { // "프로그램 실행" 버튼
             std::wstring filePath = OpenFileDialog(hwnd);
             if (!filePath.empty()) {
                 RunProgramOnCurrentMonitor(filePath);
             }
+        } else if (LOWORD(wParam) == 2) { // "종료" 버튼
+            PostQuitMessage(0);
         }
         break;
 


### PR DESCRIPTION
사용자 요청에 따라 프로그램의 GUI를 다음과 같이 수정했습니다:

- 기존 버튼의 레이블을 "프로그램 실행"으로 변경하고, 프로그램을 선택하여 현재 모니터에 실행하는 기능을 유지합니다.
- "종료" 버튼을 새로 추가하여 사용자가 프로그램을 쉽게 종료할 수 있도록 합니다.

main.cpp의 WndProc 함수 내 WM_CREATE 및 WM_COMMAND 메시지 처리 로직을 수정하여 두 개의 버튼을 구현하고 각 버튼에 맞는 동작을 할당했습니다.