### PR TITLE
chore: Update .gitignore for pyinstaller artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ env/
 # IDEs
 .vscode/
 .idea/
+
+# Pyinstaller
+build/
+dist/
+*.spec


### PR DESCRIPTION
Adds pyinstaller's build artifacts (`build/`, `dist/`, and `*.spec`) to the .gitignore file to prevent them from being committed to the repository.