### PR TITLE
fix: Add run.py entry point for pyinstaller build

### DIFF
--- a/monitor_selector/main.py
+++ b/monitor_selector/main.py
@@ -120,5 +120,5 @@ class App(tk.Tk):
             messagebox.showerror("Error", f"Failed to launch program: {e}")
 
 
-if __name__ == "__main__":
-    print("Tkinter App structure created. Cannot run mainloop in headless environment.")
+# This file is intended to be used as a module.
+# To run the application, please execute the `run.py` script in the project root.

--- a/run.py
+++ b/run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+This script is the main entry point for the application,
+especially for packaging with PyInstaller.
+"""
+
+from monitor_selector.main import App
+
+def main():
+    """
+    Initializes and runs the Tkinter application.
+    """
+    app = App()
+    app.mainloop()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This commit resolves an `ImportError` when building the application with PyInstaller. The error was caused by PyInstaller attempting to run a file from within a package that uses relative imports.

- Adds a new `run.py` script in the project root to serve as a clean entry point for the application.
- Modifies `monitor_selector/main.py` to remove the redundant `if __name__ == "__main__"` block, enforcing `run.py` as the sole entry point.

This change allows PyInstaller to correctly bundle the application without pathing or import issues.